### PR TITLE
Add leftChildren and rightChildren support to BasePage component and implement tests

### DIFF
--- a/src/assets/css/basepage.module.css
+++ b/src/assets/css/basepage.module.css
@@ -1,17 +1,25 @@
 .baseWrapper {
-  width: 100%;
-  max-width: 80vw;
-  min-height: 85vh;
+  max-width: 100vw;
+  min-height: min-content;
   padding: 1rem;
   margin: 1.5vh auto 0 auto;
   background-color: rgba(0, 0, 0, 0.25);
   box-shadow: 0px 4px 20px rgba(0, 0, 0, 0.1);
   border-radius: 8px;
-  flex-direction: column;
-  align-items: center;
+  display: flex;
+  flex-direction: row;
   justify-content: center;
+  box-sizing: border-box; /* Ensure padding is included in width/height */
 }
 
+/* Define left and right halves */
+.leftHalf, .rightHalf {
+  flex: 1;
+  padding: 1rem;
+  box-sizing: border-box; /* Ensure padding doesn't cause overflow */
+}
+
+/* Media query for smaller screens */
 @media (max-width: 768px) {
   .baseWrapper {
     width: 100%;
@@ -20,16 +28,25 @@
     background-color: transparent;
     border-radius: 0;
     box-shadow: none;
+    flex-direction: column;
+  }
+
+  /* Stack left and right halves vertically on small screens */
+  .leftHalf, .rightHalf {
+    width: 100%;
+    padding: 0.5rem 0 0 0;
   }
 }
 
-@media (min-width: 768px) {
+/* Media query for larger screens (tablets) */
+@media (min-width: 820px) {
   .baseWrapper {
-    width: 80%;
+    width: 90%;
   }
 }
 
-@media (min-width: 1200px) {
+/* Media query for desktops */
+@media (min-width: 1300px) {
   .baseWrapper {
     width: 65%;
   }

--- a/src/assets/css/header.module.css
+++ b/src/assets/css/header.module.css
@@ -67,12 +67,12 @@
 .hamburger {
   display: none;
   cursor: pointer;
-  width: 10%;
-  height: 10%;
+  width: 3rem;
+  height: 3rem;
 }
 
 /* Media query for mobile devices */
-@media (max-width: 768px) {
+@media (max-width: 1000px) {
   .hamburger {
     display: block;
   }

--- a/src/components/BasePage.js
+++ b/src/components/BasePage.js
@@ -1,7 +1,24 @@
 import React from 'react';
 import styles from '../assets/css/basepage.module.css';
 
-function BasePage({ children }) {
+function BasePage({ leftChildren, rightChildren, children }) {
+  if ((leftChildren || rightChildren) && children) {
+    console.warn("BasePage: Both children and leftChildren/rightChildren were provided. children will be ignored.");
+  }
+
+  if (leftChildren || rightChildren) {
+    return (
+      <div className={styles.baseWrapper}>
+        <div className={styles.leftHalf}>
+          {leftChildren || null}
+        </div>
+        <div className={styles.rightHalf}>
+          {rightChildren || null}
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className={styles.baseWrapper}>
       {children}

--- a/src/tests/BasePage.test.js
+++ b/src/tests/BasePage.test.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import BasePage from '../components/BasePage';
+
+describe('BasePage Component', () => {
+  const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+  afterEach(() => {
+    consoleWarnSpy.mockClear();
+  });
+
+  afterAll(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  test('renders children when no leftChildren or rightChildren are provided', () => {
+    render(<BasePage>Content</BasePage>);
+
+    const content = screen.getByText('Content');
+    expect(content).toBeInTheDocument();
+  });
+
+  test('renders leftChildren and rightChildren when provided, and ignores children', () => {
+    render(
+      <BasePage leftChildren={<div>Left Content</div>} rightChildren={<div>Right Content</div>}>
+        Main Content
+      </BasePage>
+    );
+
+    const leftContent = screen.getByText('Left Content');
+    const rightContent = screen.getByText('Right Content');
+    const mainContent = screen.queryByText('Main Content');
+
+    expect(leftContent).toBeInTheDocument();
+    expect(rightContent).toBeInTheDocument();
+    expect(mainContent).toBeNull(); // children should be ignored
+  });
+
+  test('logs a warning if both children and leftChildren/rightChildren are provided', () => {
+    render(
+      <BasePage leftChildren={<div>Left Content</div>} rightChildren={<div>Right Content</div>}>
+        Main Content
+      </BasePage>
+    );
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      'BasePage: Both children and leftChildren/rightChildren were provided. children will be ignored.'
+    );
+  });
+});


### PR DESCRIPTION
- updated the layout to dynamically render either the single children or the two-column structure based on the provided props (leftChildren & rightChildren)
- implemented logic to warn users if both children and leftChildren/rightChildren are passed, making sure the children prop is ignored in this case
- updated the layout to dynamically render either the single children or the two-column structure based on the provided props
- added a full test suite using React Testing Library and Jest, covering:
  - rendering children only
  - rendering leftChildren and rightChildren while ignoring children
  - logging a warning when both children and leftChildren/rightChildren are provided
- improved CSS support for various devices to allow for better scrolling using @media to stack leftChildren and rightChildren depending on the width of the screen width of the device