### PR TITLE
fix: Configure Git user name and email in the deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,12 @@ jobs:
       - name: Build the app
         run: npm run build
 
+      # Set up Git config for the deploy step
+      - name: Configure Git
+        run: |
+          git config --global user.email "khalid.kanaan.ca@gmail.ca"
+          git config --global user.name "Khalid Kana'an"
+
       # Deploy to GitHub Pages
       - name: Deploy to GitHub Pages
         run: npm run deploy


### PR DESCRIPTION
- added a step to the 'deploy.yml' GitHub Actions workflow to configure Git with 'user.name' and 'user.email'
- this resolves the 'Author identity unknown' error during deployment, allowing the 'gh-pages' package to push the build to the 'gh-pages' branch with the correct author information.